### PR TITLE
Expand range of eyeglass compatibility to include 1.x versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "background-image"
   ],
   "eyeglass": {
-    "needs": "^0.8.0",
+    "needs": ">=0.8.0",
     "name": "inline-svg",
     "exports": "eyeglass-exports.js"
   },


### PR DESCRIPTION
Eyeglass is now version 1.1.2! so the former `needs` line produces a compatibility warning for those that have upgraded. 

```
The following modules are incompatible with eyeglass 1.1.2:
  inline-svg needed eyeglass ^0.8.0
```
